### PR TITLE
switched entries in interfacecombobox to make it work for osx

### DIFF
--- a/src/qjackctlInterfaceComboBox.cpp
+++ b/src/qjackctlInterfaceComboBox.cpp
@@ -425,7 +425,7 @@ void qjackctlInterfaceComboBox::populateModel (void)
 							// only show human readable name
 							// humanreadable \t UID
 							sSubName = QString(coreDeviceName);
-							addCard(sSubName, sName);
+							addCard(sName, sSubName);
 							if (sCurName == sName || sCurName == sSubName)
 								iCurCard = iCards;
 							++iCards;


### PR DESCRIPTION
This change makes sure the device name needed for the jack server startup command line will be used under osx.