### PR TITLE
include <unistd.h> again

### DIFF
--- a/src/qjackctl.cpp
+++ b/src/qjackctl.cpp
@@ -65,6 +65,8 @@ const WindowFlags WindowCloseButtonHint = WindowFlags(0x08000000);
 #ifdef CONFIG_X11
 #ifdef CONFIG_XUNIQUE
 
+#include <unistd.h> /* for gethostname() */
+
 #include <QX11Info>
 
 #include <X11/Xatom.h>


### PR DESCRIPTION
Hi,

Commit 5e9eb4e32a1233ca92ec3684c357cec33a38d18b
removed #include unistd.h, but this source file uses
gethostname() if CONFIG_X11 and CONFIG_XUNIQUE are defined.

On Linux the ALSA headers include unistd.h anyway, but this
broke the build on Debian GNU/kFreeBSD and Hurd.

So, adding this back in, guarded by those macros just in case
some platforms don't have or need it.

Thanks!