### PR TITLE
Fix build error caused by variable length array

### DIFF
--- a/src/qjackctlInterfaceComboBox.cpp
+++ b/src/qjackctlInterfaceComboBox.cpp
@@ -210,7 +210,7 @@ private:
 
 			// Fill HostApi info...
 			const PaHostApiIndex iNumHostApi = Pa_GetHostApiCount();
-			QString hostNames[iNumHostApi];
+			QString *hostNames = new QString[iNumHostApi];
 			for (PaHostApiIndex i = 0; i < iNumHostApi; ++i)
 				hostNames[i] = QString(Pa_GetHostApiInfo(i)->name);
 
@@ -228,6 +228,7 @@ private:
 				}
 			}
 
+			delete [] hostNames;
 			Pa_Terminate();
 		}
 	}


### PR DESCRIPTION
LLVM/Clang complains about "variable length array of non-PO element type
'QString'" when compiled on Mac OS X. This error can be resolved by using
a dynamically allocated array instead.

Fixes #17.