### PR TITLE
Display non-physical terminal ports in duplex mode

### DIFF
--- a/src/qjackctlJackGraph.cpp
+++ b/src/qjackctlJackGraph.cpp
@@ -219,7 +219,7 @@ bool qjackctlJackGraph::findClientPort ( jack_client_t *client,
 
 	if (*node == NULL) {
 		const unsigned long port_flags = ::jack_port_flags(jack_port);
-		if ((port_flags & (JackPortIsPhysical | JackPortIsTerminal)) == 0) {
+		if ((port_flags & (JackPortIsPhysical | JackPortIsTerminal)) != (JackPortIsPhysical | JackPortIsTerminal)) {
 			node_mode = qjackctlGraphItem::Duplex;
 			*node = qjackctlGraphSect::findNode(client_name, node_mode, node_type);
 		}


### PR DESCRIPTION
In the case of a synthesizer, Zynaddsubfx, which has midi-ins and audio-outs described as terminal, the graph view is going to split the display of the JACK client into two separate nodes.

By comparison, if you run Zynaddsubfx as LV2 under Jalv, it will be single node in this case, because it will not declare ports as terminal.

To make the situation more consistent, I thought this fix to be appropriate: only split in case of both `IsTerminal` and `IsPhysical`. (being the case of I/O of a hardware audio interface, I suppose)