### PR TITLE
Resolve some memory corruptions

### DIFF
--- a/src/qjackctlGraph.cpp
+++ b/src/qjackctlGraph.cpp
@@ -1183,6 +1183,8 @@ void qjackctlGraphCanvas::addItem ( qjackctlGraphItem *item )
 
 void qjackctlGraphCanvas::removeItem ( qjackctlGraphItem *item )
 {
+	clearSelection();
+
 	if (item->type() == qjackctlGraphNode::Type) {
 		qjackctlGraphNode *node = static_cast<qjackctlGraphNode *> (item);
 		if (node && saveNodePos(node)) {

--- a/src/qjackctlJackConnect.cpp
+++ b/src/qjackctlJackConnect.cpp
@@ -240,8 +240,9 @@ void qjackctlJackClient::updateClientName ( bool bRename )
 		bool bRenameEnabled = false;
 		QString sClientNameEx = clientNameAlias(&bRenameEnabled);
 		const QString& sClientName = clientName();
+		const QByteArray aClientName = sClientName.toUtf8();
 		const char *pszClientName
-			= sClientName.toUtf8().constData();
+			= aClientName.constData();
 		const char *pszClientUuid
 			= ::jack_get_uuid_for_client_name(pJackClient, pszClientName);
 		if (pszClientUuid) {


### PR DESCRIPTION
#59 

I unset the selection of the scene on item deletion, which prevents the item just removed to be picked as the `currentItem` at later point and crash.

This may or not may be the preferred solution. In my situation, the crash was resolved.