### PR TITLE
Remove QPlastiqueStyle usage

### DIFF
--- a/src/qjackctlMainForm.cpp
+++ b/src/qjackctlMainForm.cpp
@@ -60,10 +60,6 @@
 #include <QContextMenuEvent>
 #include <QCloseEvent>
 
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
-#include <QPlastiqueStyle>
-#endif
-
 
 #if QT_VERSION < QT_VERSION_CHECK(4, 5, 0)
 namespace Qt {
@@ -406,10 +402,6 @@ qjackctlMainForm::qjackctlMainForm (
 	QWidget *pParent, Qt::WindowFlags wflags )
 	: QWidget(pParent, wflags), m_menu(this)
 {
-#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
-	QApplication::setStyle(new QPlastiqueStyle());
-#endif
-
 	// Setup UI struct...
 	m_ui.setupUi(this);
 


### PR DESCRIPTION
When compiling qjackctl from git with Qt 5.9 on Windows, there is an
error about QPlastiqueStyle: No such file or directory.

The offending code is:
https://github.com/rncbc/qjackctl/blob/aa73c02cdb81073c36efeb84805567676a612ddf/src/qjackctlMainForm.cpp#L63-L65

Where QPlastiqueStyle is used only here:
https://github.com/rncbc/qjackctl/blob/aa73c02cdb81073c36efeb84805567676a612ddf/src/qjackctlMainForm.cpp#L409-L411

Qt 5 seems to have replaced Plastique style with Fusion, and so
QPlastiqueStyle does not exists. This include is only made on Windows
given the ifdefs.

I think that include (and related usage of QPlastiqueStyle) should be
removed as Windows native style is working and will probably
look better integrated than a different custom style.