### PR TITLE
- Make Graph window behavior like other forms

### DIFF
--- a/src/qjackctlMainForm.cpp
+++ b/src/qjackctlMainForm.cpp
@@ -688,7 +688,7 @@ bool qjackctlMainForm::setup ( qjackctlSetup *pSetup )
 	m_pPatchbayForm       = new qjackctlPatchbayForm       (pParent, wflags);
 
 	// Graph form should be a full-blown top-level window...
-	m_pGraphForm = new qjackctlGraphForm(this);
+	m_pGraphForm = new qjackctlGraphForm(pParent, wflags);
 
 	// Setup form is kind of special (modeless dialog).
 	m_pSetupForm = new qjackctlSetupForm(this);


### PR DESCRIPTION
Previously, the Graph window was always behaving like "Keep child windows
always on top" option was enabled even if it wasn't.

That is, the Graph window was always over the qjackctl main gui and on
Windows, there was no way to differentiate the main gui to the Graph
window in the taskbar.

Fix this by using the same constructor arguments as other forms, so the Graph window respect the "Keep child windows always on top" option.
I've tested it, both when enabled and disabled, and there is no issues, the Graph window behavior is fine (even if it's a QMainWindow)

See also: https://stackoverflow.com/a/52282886
