### PR TITLE
Fix win32 build

### DIFF
--- a/src/qjackctlGraph.cpp
+++ b/src/qjackctlGraph.cpp
@@ -51,6 +51,7 @@
 
 #include <algorithm>
 
+#define _USE_MATH_DEFINES
 #include <math.h>
 
 


### PR DESCRIPTION
Macro is necessary on windows, otherwise the M_PI macro is missing.
Build fails with:
```
qjackctlGraph.cpp: In member function 'void qjackctlGraphConnect::updatePathTo(const QPointF&)':
qjackctlGraph.cpp:982:55: error: 'M_PI' was not declared in this scope
  982 |  const qreal arrow_angle = path.angleAtPercent(0.5) * M_PI / 180.0;
```