### PR TITLE
Tweaks for macOS/win32 behaviour

### DIFF
--- a/src/qjackctlAboutForm.cpp
+++ b/src/qjackctlAboutForm.cpp
@@ -68,12 +68,12 @@ qjackctlAboutForm::qjackctlAboutForm ( QWidget *pParent )
 	list << tr("JACK Session support disabled.");
 #endif
 #ifndef CONFIG_ALSA_SEQ
-#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32)
+#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32) && !defined(__APPLE__)
 	list << tr("ALSA/MIDI sequencer support disabled.");
 #endif
 #endif
 #ifndef CONFIG_DBUS
-#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32)
+#if !defined(__WIN32__) && !defined(_WIN32) && !defined(WIN32) && !defined(__APPLE__)
 	list << tr("D-Bus interface support disabled.");
 #endif
 #endif

--- a/src/qjackctlMainForm.cpp
+++ b/src/qjackctlMainForm.cpp
@@ -584,6 +584,26 @@ qjackctlMainForm::qjackctlMainForm (
 	QObject::connect(m_ui.ForwardToolButton,
 		SIGNAL(clicked()),
 		SLOT(transportForward()));
+
+#ifdef __APPLE__
+	// Setup macOS menu bar
+	QMenuBar* const menuBar = new QMenuBar(nullptr);
+	menuBar->setNativeMenuBar(true);
+
+	QMenu* const menu = menuBar->addMenu("QjackCtl");
+
+	QAction* const actQuit = menu->addAction(tr("&Quit"));
+	actQuit->setMenuRole(QAction::QuitRole);
+	QObject::connect(actQuit, SIGNAL(triggered()), SLOT(quitMainForm()));
+
+	QAction* const actPreferences = menu->addAction(tr("Set&up..."));
+	actPreferences->setMenuRole(QAction::PreferencesRole);
+	QObject::connect(actPreferences, SIGNAL(triggered()), SLOT(showSetupForm()));
+
+	QAction* const actAbout = menu->addAction(tr("Ab&out..."));
+	actAbout->setMenuRole(QAction::AboutRole);
+	QObject::connect(actAbout, SIGNAL(triggered()), SLOT(showAboutForm()));
+#endif
 }
 
 
@@ -905,6 +925,11 @@ bool qjackctlMainForm::setup ( qjackctlSetup *pSetup )
 
 	// Register the first timer slot.
 	QTimer::singleShot(QJACKCTL_TIMER_MSECS, this, SLOT(timerSlot()));
+
+#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__APPLE__)
+	// increazing height make UI look ugly and it is not really useful
+	setFixedHeight(height());
+#endif
 
 	// We're ready to go...
 	return true;

--- a/src/qjackctlSetup.cpp
+++ b/src/qjackctlSetup.cpp
@@ -80,6 +80,12 @@ void qjackctlSetup::loadSetup (void)
 	}
 	m_settings.endGroup();
 
+#ifdef __APPLE__
+	// alternative custom defaults, as the mac theme does not look good with our custom widgets
+	sCustomColorTheme = "KXStudio";
+	sCustomStyleTheme = "Fusion";
+#endif
+
 	m_settings.beginGroup("/Options");
 	bSingleton               = m_settings.value("/Singleton", true).toBool();
 //	sServerName              = m_settings.value("/ServerName").toString();
@@ -110,8 +116,8 @@ void qjackctlSetup::loadSetup (void)
 	sDisplayFont2            = m_settings.value("/DisplayFont2").toString();
 	bDisplayEffect           = m_settings.value("/DisplayEffect", true).toBool();
 	bDisplayBlink            = m_settings.value("/DisplayBlink", true).toBool();
-	sCustomColorTheme        = m_settings.value("/CustomColorTheme").toString();
-	sCustomStyleTheme        = m_settings.value("/CustomStyleTheme").toString();
+	sCustomColorTheme        = m_settings.value("/CustomColorTheme", sCustomColorTheme).toString();
+	sCustomStyleTheme        = m_settings.value("/CustomStyleTheme", sCustomStyleTheme).toString();
 	iJackClientPortAlias     = m_settings.value("/JackClientPortAlias", 0).toInt();
 	bJackClientPortMetadata  = m_settings.value("/JackClientPortMetadata", false).toBool();
 	iConnectionsIconSize     = m_settings.value("/ConnectionsIconSize", QJACKCTL_ICON_16X16).toInt();

--- a/src/qjackctlSetupForm.cpp
+++ b/src/qjackctlSetupForm.cpp
@@ -127,6 +127,29 @@ qjackctlSetupForm::qjackctlSetupForm ( QWidget *pParent )
 	m_iDirtySettings = 0;
 	m_iDirtyOptions = 0;
 
+#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__APPLE__)
+	// Remove useless drivers for some systems
+	for (int i = m_ui.DriverComboBox->count(); --i >= 0;)
+	{
+		const QString itemText = m_ui.DriverComboBox->itemText(i);
+		if (itemText == "dummy")
+			continue;
+#if defined(__WIN32__) || defined(_WIN32) || defined(WIN32)
+		if (itemText == "portaudio")
+			continue;
+#endif
+#ifdef __APPLE__
+		if (itemText == "coreaudio")
+			continue;
+#endif
+		if (itemText == "net")
+			continue;
+		if (itemText == "netone")
+			continue;
+		m_ui.DriverComboBox->removeItem(i);
+	}
+#endif
+
 	// Save original hard-coded driver names, only really
 	// useful when (changing (dis)enabling JACK D-BUS...
 	m_drivers.clear();


### PR DESCRIPTION
This brings a few tweaks to make qjackctl behave better under macOS, some applied to win32 too:

1. adds a few macOS native menu bar items
2. hides alsa-midi and dbus unavailable text strings in about dialog for macOS (obviously those 2 dont work there)
3. makes the main UI fixed height, as increasing height really does not make sense here (this could be applied for all OSes maybe?)
4. sets a custom theme and color scheme as default in macOS, as qt mac look does not fit qjackctl very well
5. only shows audio drivers that are known to work for macOS/win32