### PR TITLE
[windows] Rework installed files: only binaries and translations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ option (CONFIG_STACKTRACE "Enable debugger stack-trace (default=no)" 0)
 # Enable Qt6 build preference.
 option (CONFIG_QT6 "Enable Qt6 build (default=yes)" 1)
 
+# Enable install QT DLLs for Windows targets using windeployqt.
+option (CONFIG_INSTALL_QT_DLLS "Install QT DLLs for Windows targets (default=no)" 0)
+
 
 # Fix for new CMAKE_REQUIRED_LIBRARIES policy.
 if (POLICY CMP0075)
@@ -270,10 +273,13 @@ endif ()
 
 add_subdirectory (src)
 
-configure_file (qjackctl.spec.in qjackctl.spec IMMEDIATE @ONLY)
+if (NOT WIN32)
+  configure_file (qjackctl.spec.in qjackctl.spec IMMEDIATE @ONLY)
 
-install (FILES qjackctl.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
-install (FILES qjackctl.fr.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/fr/man1 RENAME qjackctl.1)
+  install (FILES qjackctl.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+  install (FILES qjackctl.fr.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/fr/man1 RENAME qjackctl.1)
+endif ()
+
 
 # Configuration status
 macro (SHOW_OPTION text value)
@@ -308,5 +314,7 @@ message     ("")
 show_option ("  System tray icon support . . . . . . . . . . . . ." CONFIG_SYSTEM_TRAY)
 show_option ("  Unique/Single instance support . . . . . . . . . ." CONFIG_XUNIQUE)
 show_option ("  Debugger stack-trace (gdb) . . . . . . . . . . . ." CONFIG_STACKTRACE)
+show_option ("  Install Qt DLLs on Windows . . . . . . . . . . . ." CONFIG_INSTALL_QT_DLLS)
 message   ("\n  Install prefix . . . . . . . . . . . . . . . . . .: ${CONFIG_PREFIX}")
 message   ("\nNow type 'make', followed by 'make install' as root.\n")
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
-    file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
+  file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 endif ()
 configure_file (cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
@@ -162,20 +162,57 @@ if (CONFIG_COREAUDIO)
 endif ()
 
 
-if (NOT APPLE)
+if (UNIX AND NOT APPLE)
   install (TARGETS ${PROJECT_NAME} RUNTIME
      DESTINATION ${CMAKE_INSTALL_BINDIR})
   install (FILES ${QM_FILES}
      DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/translations)
+  install (FILES ${PROJECT_NAME}.desktop
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+  install (FILES images/${PROJECT_NAME}.png
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
+  install (FILES images/${PROJECT_NAME}.svg
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
+  install (FILES appdata/${PROJECT_NAME}.appdata.xml
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+endif ()
 
-  if (NOT WIN32)
-    install (FILES ${PROJECT_NAME}.desktop
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-    install (FILES images/${PROJECT_NAME}.png
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
-    install (FILES images/${PROJECT_NAME}.svg
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
-    install (FILES appdata/${PROJECT_NAME}.appdata.xml
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+if (WIN32)
+  install (TARGETS ${PROJECT_NAME} RUNTIME
+     DESTINATION .)
+  # Use same path as windeployqt for translations
+  install (FILES ${QM_FILES}
+     DESTINATION translations)
+endif ()
+
+if (WIN32 AND CONFIG_INSTALL_QT_DLLS)
+  get_target_property (_qt_qmake_location Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+  get_filename_component (_qt_bin_dir "${_qt_qmake_location}" DIRECTORY)
+  set (QT_WINDEPLOYQT "${_qt_bin_dir}/windeployqt.exe")
+
+  if (EXISTS ${QT_WINDEPLOYQT})
+    # execute windeployqt in a tmp directory after build
+    add_custom_command (TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
+      COMMAND set PATH=${_qt_bin_dir}$<SEMICOLON>%PATH%
+      COMMAND "${QT_WINDEPLOYQT}"
+        --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
+        --no-quick-import
+        --no-opengl-sw
+        --no-virtualkeyboard
+        --no-webkit2
+        --no-angle
+        --no-svg
+        "$<TARGET_FILE:${PROJECT_NAME}>"
+      USES_TERMINAL
+    )
+
+    # copy deployment directory during installation
+    install (
+      DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
+      DESTINATION .
+    )
   endif ()
 endif ()

--- a/src/qjackctl.cpp
+++ b/src/qjackctl.cpp
@@ -32,6 +32,7 @@
 #include <QLibraryInfo>
 #include <QTranslator>
 #include <QLocale>
+#include <QCoreApplication>
 
 #include <QSessionManager>
 
@@ -127,7 +128,11 @@ qjackctlApplication::qjackctlApplication ( int& argc, char **argv )
 		if (m_pMyTranslator->load(sLocName, sLocPath)) {
 			QApplication::installTranslator(m_pMyTranslator);
 		} else {
+#ifndef _WIN32
 			sLocPath = CONFIG_DATADIR "/qjackctl/translations";
+#else
+			sLocPath = QCoreApplication::applicationDirPath() + "/translations";
+#endif
 			if (m_pMyTranslator->load(sLocName, sLocPath)) {
 				QApplication::installTranslator(m_pMyTranslator);
 			} else {


### PR DESCRIPTION
**This PR requires https://github.com/rncbc/qjackctl/pull/146 to be merged before**
This PR contains only one commit, others are from PR #146.

This PR adjusts installed file for Windows:    
 - Don't install manpages and spec file for Windows.
 - Install Qt's DLLs using windeployqt when CONFIG_INSTALL_QT_DLLS is ON.
 - Install and adjust translation path to match the one used by windeployqt.

windeployqt is a tool supplied with Qt which find which DLLs are required
for the application.

This makes qjackctl useable as-is in its install directory without additional required runtime files (and it finds translations):
![image](https://user-images.githubusercontent.com/5435069/130162618-8e3550c6-06c8-4181-b901-4b8522365b68.png)
![image](https://user-images.githubusercontent.com/5435069/130162750-783c4601-ead6-4c2d-b18f-1b5dcaa38042.png)
