### PR TITLE
[ci] Add github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,141 @@
+# This is a basic workflow to help you get started with Actions
+
+name: main
+
+# Controls when the workflow will run
+# Triggers the workflow on push or pull request events
+on: [ push, pull_request ]
+
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # Linux build
+  linux:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # do builds with both Jack 1 and Jack 2
+    strategy:
+      matrix:
+        jack_package:
+          - libjack-jackd2-dev
+          - libjack-dev
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential ninja-build cmake qttools5-dev qtbase5-dev libasound2-dev portaudio19-dev ${{ matrix.jack_package }}
+
+      # Runs a set of commands using the runners shell
+      - name: Build
+        run: |
+          git submodule -q update --init --recursive
+          mkdir build
+          mkdir qjackctl-install
+          cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+          DESTDIR=$PWD/qjackctl-install cmake --build build --target install --config RelWithDebInfo
+          tar -czf qjackctl-build.tar.gz qjackctl-install
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          # Artifact name
+          name: "qjackctl-${{ runner.os }}-${{ github.job }}-${{ matrix.jack_package }}.tar.gz" # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: qjackctl-build.tar.gz
+
+  # MacOS build
+  macos:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          brew install cmake ninja qt jack
+
+      # Runs a set of commands using the runners shell
+      - name: Build
+        run: |
+          git submodule -q update --init --recursive
+          mkdir build
+          mkdir qjackctl-install
+          cmake -S . -B build -GNinja -DCMAKE_INSTALL_PREFIX=/usr
+          DESTDIR=$PWD/qjackctl-install cmake --build build --target install --config RelWithDebInfo
+          tar -czf qjackctl-build.tar.gz qjackctl-install
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          # Artifact name
+          name: "qjackctl-${{ runner.os }}-${{ github.job }}.tar.gz" # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: qjackctl-build.tar.gz
+          
+  # Windows 32 and 64 bits build
+  windows:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        config:
+          - arch: 32
+            choco_opts: "--forceX86"
+          - arch: 64
+            choco_opts: ""
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Install dependencies
+        run: |
+          $JACK_VERSION="v1.9.19"
+          echo "Downloading Jack win${{ matrix.config.arch }} $JACK_VERSION ..."
+          $exePath = "$($env:TEMP)\jack2_installer.exe"
+          (New-Object Net.WebClient).DownloadFile("https://github.com/jackaudio/jack2-releases/releases/download/$JACK_VERSION/jack2-win${{ matrix.config.arch }}-$JACK_VERSION.exe", $exePath)
+          echo "Installing..."
+          cmd /c start /wait $exePath /SILENT /NORESTART /NOICONS /TYPE=full
+          echo "Done installing Jack win${{ matrix.config.arch }} $JACK_VERSION"
+          
+          choco install qt5-default --version=5.15.2 ${{ matrix.config.choco_opts }}
+          if ( ${{ matrix.config.arch }} -eq 32 ) { choco install mingw --force --version=8.1.0 ${{ matrix.config.choco_opts }} }
+
+      # Runs a set of commands using the runners shell
+      - name: Build
+        run: |
+          $env:CC="gcc.exe"
+          $env:CXX="g++.exe"
+          $env:PATH="C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw${{ matrix.config.arch }}\bin;$env:PATH"
+          $env:DESTDIR="$PWD/qjackctl-install"
+          git submodule -q update --init --recursive
+          mkdir build
+          mkdir qjackctl-install
+          
+          cmake -S . -B build "-GMinGW Makefiles" "-DCMAKE_PREFIX_PATH=C:\Qt\5.15.2\mingw81_${{ matrix.config.arch }}\lib\cmake" "-DCMAKE_INSTALL_PREFIX="
+          if ($lastexitcode -ne 0) { exit $lastexitcode }
+          
+          cmake --build build --target install --config RelWithDebInfo -- -j4
+          if ($lastexitcode -ne 0) { exit $lastexitcode }
+          
+          tar -czf qjackctl-build.tar.gz qjackctl-install
+          if ($lastexitcode -ne 0) { exit $lastexitcode }
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.4
+        with:
+          # Artifact name
+          name: "qjackctl-${{ runner.os }}-${{ github.job }}${{ matrix.config.arch }}.tar.gz" # optional, default is artifact
+          # A file, directory or wildcard pattern that describes what to upload
+          path: qjackctl-build.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,14 @@ if (NOT WIN32)
   install (FILES qjackctl.fr.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/fr/man1 RENAME qjackctl.1)
 endif ()
 
+if (WIN32)
+  set(CPACK_GENERATOR ZIP)
+else ()
+  set(CPACK_GENERATOR TGZ)
+endif ()
+
+include(CPack)
+
 
 # Configuration status
 macro (SHOW_OPTION text value)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,9 @@ option (CONFIG_STACKTRACE "Enable debugger stack-trace (default=no)" 0)
 # Enable Qt6 build preference.
 option (CONFIG_QT6 "Enable Qt6 build (default=yes)" 1)
 
+# Enable install QT DLLs for Windows targets using windeployqt.
+option (CONFIG_INSTALL_QT_DLLS "Install QT DLLs for Windows targets (default=no)" 0)
+
 
 # Fix for new CMAKE_REQUIRED_LIBRARIES policy.
 if (POLICY CMP0075)
@@ -270,10 +273,13 @@ endif ()
 
 add_subdirectory (src)
 
-configure_file (qjackctl.spec.in qjackctl.spec IMMEDIATE @ONLY)
+if (NOT WIN32)
+  configure_file (qjackctl.spec.in qjackctl.spec IMMEDIATE @ONLY)
 
-install (FILES qjackctl.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
-install (FILES qjackctl.fr.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/fr/man1 RENAME qjackctl.1)
+  install (FILES qjackctl.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+  install (FILES qjackctl.fr.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/fr/man1 RENAME qjackctl.1)
+endif ()
+
 
 # Configuration status
 macro (SHOW_OPTION text value)
@@ -308,5 +314,7 @@ message     ("")
 show_option ("  System tray icon support . . . . . . . . . . . . ." CONFIG_SYSTEM_TRAY)
 show_option ("  Unique/Single instance support . . . . . . . . . ." CONFIG_XUNIQUE)
 show_option ("  Debugger stack-trace (gdb) . . . . . . . . . . . ." CONFIG_STACKTRACE)
+show_option ("  Install Qt DLLs on Windows . . . . . . . . . . . ." CONFIG_INSTALL_QT_DLLS)
 message   ("\n  Install prefix . . . . . . . . . . . . . . . . . .: ${CONFIG_PREFIX}")
 message   ("\nNow type 'make', followed by 'make install' as root.\n")
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ set (CMAKE_AUTOMOC ON)
 set (CMAKE_AUTORCC ON)
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
-    file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
+  file (REMOVE ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 endif ()
 configure_file (cmake_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)
 
@@ -162,20 +162,57 @@ if (CONFIG_COREAUDIO)
 endif ()
 
 
-if (NOT APPLE)
+if (UNIX AND NOT APPLE)
   install (TARGETS ${PROJECT_NAME} RUNTIME
      DESTINATION ${CMAKE_INSTALL_BINDIR})
   install (FILES ${QM_FILES}
      DESTINATION ${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}/translations)
+  install (FILES ${PROJECT_NAME}.desktop
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
+  install (FILES images/${PROJECT_NAME}.png
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
+  install (FILES images/${PROJECT_NAME}.svg
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
+  install (FILES appdata/${PROJECT_NAME}.appdata.xml
+     DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+endif ()
 
-  if (NOT WIN32)
-    install (FILES ${PROJECT_NAME}.desktop
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/applications)
-    install (FILES images/${PROJECT_NAME}.png
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/32x32/apps)
-    install (FILES images/${PROJECT_NAME}.svg
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/icons/hicolor/scalable/apps)
-    install (FILES appdata/${PROJECT_NAME}.appdata.xml
-       DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
+if (WIN32)
+  install (TARGETS ${PROJECT_NAME} RUNTIME
+     DESTINATION .)
+  # Use same path as windeployqt for translations
+  install (FILES ${QM_FILES}
+     DESTINATION translations)
+endif ()
+
+if (WIN32 AND CONFIG_INSTALL_QT_DLLS)
+  get_target_property (_qt_qmake_location Qt${QT_VERSION_MAJOR}::qmake IMPORTED_LOCATION)
+  get_filename_component (_qt_bin_dir "${_qt_qmake_location}" DIRECTORY)
+  set (QT_WINDEPLOYQT "${_qt_bin_dir}/windeployqt.exe")
+
+  if (EXISTS ${QT_WINDEPLOYQT})
+    # execute windeployqt in a tmp directory after build
+    add_custom_command (TARGET ${PROJECT_NAME}
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E remove_directory "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
+      COMMAND set PATH=${_qt_bin_dir}$<SEMICOLON>%PATH%
+      COMMAND "${QT_WINDEPLOYQT}"
+        --dir "${CMAKE_CURRENT_BINARY_DIR}/windeployqt"
+        --no-quick-import
+        --no-opengl-sw
+        --no-virtualkeyboard
+        --no-webkit2
+        --no-angle
+        --no-svg
+        "$<TARGET_FILE:${PROJECT_NAME}>"
+      USES_TERMINAL
+    )
+
+    # copy deployment directory during installation
+    install (
+      DIRECTORY
+      "${CMAKE_CURRENT_BINARY_DIR}/windeployqt/"
+      DESTINATION .
+    )
   endif ()
 endif ()

--- a/src/qjackctl.cpp
+++ b/src/qjackctl.cpp
@@ -32,6 +32,7 @@
 #include <QLibraryInfo>
 #include <QTranslator>
 #include <QLocale>
+#include <QCoreApplication>
 
 #include <QSessionManager>
 
@@ -127,7 +128,11 @@ qjackctlApplication::qjackctlApplication ( int& argc, char **argv )
 		if (m_pMyTranslator->load(sLocName, sLocPath)) {
 			QApplication::installTranslator(m_pMyTranslator);
 		} else {
+#ifndef _WIN32
 			sLocPath = CONFIG_DATADIR "/qjackctl/translations";
+#else
+			sLocPath = QCoreApplication::applicationDirPath() + "/translations";
+#endif
 			if (m_pMyTranslator->load(sLocName, sLocPath)) {
 				QApplication::installTranslator(m_pMyTranslator);
 			} else {


### PR DESCRIPTION
**This PR requires #148 to be merged before**
This PR contains only one commit, others are from PR #148, #147 and #146.

This PR add github actions CI script to build for:
 - Linux Ubuntu
 - Windows
   - MinGW 8.1 64 bits
   - MinGW 8.1 32 bits
 - MacOS

Builds are triggered for all push and new PRs of any branches.
I've tried to add MSVC using appveyor, but unfortunately there are errors about symbols not properly exported from Jack (I'm not sure MSVC is really supported anyway).

On Windows, portaudio is not enabled because there is no binaries of portaudio available for Windows.
The build should be adjusted to also build portaudio beforehand maybe, to have a fully-featured qjackctl.

One caveat though, github actions only detect scripts from the default branch of the repository which is `master` here until one build is least done (but I'm not sure about that).
What is working on my repository:
 - Change default branch to the one that contains `.github/workflows/main.yml`
 - Go to Actions tab in github, you should see the workflow, but without any build yet
 - Trigger a build by pushing something
 - The build should appear in Actions tab in github
 - Change the default branch back to its previous state (`master`)
 - The build should still appear in Actions tab in github
 - Pushing something in the branch that has ` .github/workflows/main.yml` should trigger builds even if it isn't the default one now

See here for a resulting build:
https://github.com/amurzeau/qjackctl/actions/runs/1149036858
