### PR TITLE
[cmake] remove duplicate CPack code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,16 +288,6 @@ endif ()
 
 include(CPack)
 
-
-if (WIN32)
-  set(CPACK_GENERATOR ZIP)
-else ()
-  set(CPACK_GENERATOR TGZ)
-endif ()
-
-include(CPack)
-
-
 # Configuration status
 macro (SHOW_OPTION text value)
   if (${value})


### PR DESCRIPTION
The duplicated code can cause CPack failure when CONFIG_INSTALL_QT_DLLS is enabled (I've seen this while trying appveyor)