### PR TITLE
Default shiny glass effect to off

### DIFF
--- a/src/qjackctlSetup.cpp
+++ b/src/qjackctlSetup.cpp
@@ -134,7 +134,7 @@ void qjackctlSetup::loadSetup (void)
 	iMessagesLimitLines      = m_settings.value("/MessagesLimitLines", 1000).toInt();
 	sDisplayFont1            = m_settings.value("/DisplayFont1").toString();
 	sDisplayFont2            = m_settings.value("/DisplayFont2").toString();
-	bDisplayEffect           = m_settings.value("/DisplayEffect", true).toBool();
+	bDisplayEffect           = m_settings.value("/DisplayEffect", false).toBool();
 	bDisplayBlink            = m_settings.value("/DisplayBlink", true).toBool();
 	sCustomColorTheme        = m_settings.value("/CustomColorTheme", sCustomColorTheme).toString();
 	sCustomStyleTheme        = m_settings.value("/CustomStyleTheme", sCustomStyleTheme).toString();


### PR DESCRIPTION
Ref #93 #159 #167

The "shiny glass effect" makes it difficult to read the display, and in my opinion, looks bad and not even like shiny glass. The GUI option for it has now gone, and so I think it's time for the actual effect to go too.