### PR TITLE
coreaudio: allow selecting separate input and output devices

### DIFF
--- a/src/qjackctlMainForm.cpp
+++ b/src/qjackctlMainForm.cpp
@@ -1569,7 +1569,7 @@ void qjackctlMainForm::startJack (void)
 			args.append("-X" + formatQuoted(m_preset.sMidiDriver));
 	#endif
 	}
-	if (bAlsa || bPortaudio) {
+	if (bAlsa || bCoreaudio || bPortaudio) {
 		switch (m_preset.iAudio) {
 		case QJACKCTL_DUPLEX:
 			if (!m_preset.sInDevice.isEmpty() || !m_preset.sOutDevice.isEmpty())

--- a/src/qjackctlSetupForm.cpp
+++ b/src/qjackctlSetupForm.cpp
@@ -1128,13 +1128,13 @@ void qjackctlSetupForm::changeDriverAudio ( const QString& sDriver, int iAudio )
 		break;
 	}
 
-	bEnabled = (bInEnabled && (bAlsa || bSun || bOss || bPortaudio));
+	bEnabled = (bInEnabled && (bAlsa || bSun || bOss || bCoreaudio || bPortaudio));
 	m_ui.InDeviceTextLabel->setEnabled(bEnabled);
 	m_ui.InDeviceComboBox->setEnabled(bEnabled);
 	if (!bEnabled)
 		setComboBoxCurrentText(m_ui.InDeviceComboBox, qjackctlSetup::defName());
 
-	bEnabled = (bOutEnabled && (bAlsa || bSun || bOss || bPortaudio));
+	bEnabled = (bOutEnabled && (bAlsa || bSun || bOss || bCoreaudio || bPortaudio));
 	m_ui.OutDeviceTextLabel->setEnabled(bEnabled);
 	m_ui.OutDeviceComboBox->setEnabled(bEnabled);
 	if (!bEnabled)


### PR DESCRIPTION
This simply enables the relevant controls in the UI. Jack itself has been supporting this for a while via a dynamically created aggregate device. Works fine for me (YMMV, might murder your kittens).

Closes #156 