### PR TITLE
Fix the pretty name metadata display in the connections window.

### DIFF
--- a/src/qjackctlJackConnect.cpp
+++ b/src/qjackctlJackConnect.cpp
@@ -131,7 +131,7 @@ void qjackctlJackPort::updatePortName ( bool bRename )
 		if (pJackPort) {
 			jack_uuid_t port_uuid = ::jack_port_uuid(pJackPort);
 			const QString& sPrettyName = prettyName(port_uuid);
-			if (sPortNameEx != sPortName && sPortNameEx != sPrettyName) {
+			if (sPortNameEx != sPortName || sPortNameEx != sPrettyName) {
 				if (sPrettyName.isEmpty() || bRename) {
 					setPrettyName(pJackClient, port_uuid, sPortNameEx);
 				} else {


### PR DESCRIPTION
We want this to be shown if it is non-empty, differs from the currently shown alias, and the port item is not edited. To these ends, fix the wrong test in qjackctlJackConnect.cpp:134 which needs to update the port name (either the pretty name or the alias) if sPortNameEx != sPortName *or* sPortNameEx != sPrettyName (not if both conditions are true at the same time, as was done previously).