### PR TITLE
More metadata fixes

### DIFF
--- a/src/qjackctlJackConnect.cpp
+++ b/src/qjackctlJackConnect.cpp
@@ -132,8 +132,8 @@ void qjackctlJackPort::updatePortName ( bool bRename )
 			jack_uuid_t port_uuid = ::jack_port_uuid(pJackPort);
 			const QString& sPrettyName = prettyName(port_uuid);
 			if (sPortNameEx != sPortName || sPortNameEx != sPrettyName) {
-				if (sPrettyName.isEmpty() || bRename) {
-					setPrettyName(pJackClient, port_uuid, sPortNameEx);
+				if (sPrettyName.isEmpty() || sPortNameEx != sPortName || bRename) {
+					removePrettyName(pJackClient, port_uuid);
 				} else {
 					sPortNameEx = sPrettyName;
 					setPortNameAlias(sPortNameEx);
@@ -248,8 +248,8 @@ void qjackctlJackClient::updateClientName ( bool bRename )
 			::jack_uuid_parse(pszClientUuid, &client_uuid);
 			const QString& sPrettyName = prettyName(client_uuid);
 			if (sClientNameEx != sClientName || sClientNameEx != sPrettyName) {
-				if (sPrettyName.isEmpty() || bRename) {
-					setPrettyName(pJackClient, client_uuid, sClientNameEx);
+				if (sPrettyName.isEmpty() || sClientNameEx != sClientName || bRename) {
+					removePrettyName(pJackClient, client_uuid);
 				} else {
 					sClientNameEx = sPrettyName;
 					setClientNameAlias(sClientNameEx);

--- a/src/qjackctlJackConnect.cpp
+++ b/src/qjackctlJackConnect.cpp
@@ -247,7 +247,7 @@ void qjackctlJackClient::updateClientName ( bool bRename )
 			jack_uuid_t client_uuid = 0;
 			::jack_uuid_parse(pszClientUuid, &client_uuid);
 			const QString& sPrettyName = prettyName(client_uuid);
-			if (sClientNameEx != sClientName && sClientNameEx != sPrettyName) {
+			if (sClientNameEx != sClientName || sClientNameEx != sPrettyName) {
 				if (sPrettyName.isEmpty() || bRename) {
 					setPrettyName(pJackClient, client_uuid, sClientNameEx);
 				} else {

--- a/src/qjackctlJackGraph.cpp
+++ b/src/qjackctlJackGraph.cpp
@@ -348,8 +348,6 @@ bool qjackctlJackGraph::findClientPort ( jack_client_t *client,
 	if (add_new && *node) {
 		int nchanged = 0;
 		QString node_title = (*node)->nodeTitle();
-		foreach (qjackctlAliasList *node_aliases, item_aliases(*node))
-			node_title = node_aliases->clientAlias(client_name);
 	#ifdef CONFIG_JACK_METADATA
 		const char *client_uuid_name
 			= ::jack_get_uuid_for_client_name(client,
@@ -364,14 +362,14 @@ bool qjackctlJackGraph::findClientPort ( jack_client_t *client,
 			::jack_free((void *) client_uuid_name);
 		}
 	#endif	// CONFIG_JACK_METADATA
+		foreach (qjackctlAliasList *node_aliases, item_aliases(*node))
+			node_title = node_aliases->clientAlias(client_name);
 		if ((*node)->nodeTitle() != node_title) {
 			(*node)->setNodeTitle(node_title);
 			++nchanged;
 		}
 		if (*port) {
 			QString port_title = (*port)->portTitle();
-			foreach (qjackctlAliasList *port_aliases, item_aliases(*port))
-				port_title = port_aliases->portAlias(client_name, port_name);
 		#ifdef CONFIG_JACK_METADATA
 			const QString& pretty_name
 				= qjackctlJackGraph_pretty_name(port_uuid, port_name);
@@ -384,6 +382,8 @@ bool qjackctlJackGraph::findClientPort ( jack_client_t *client,
 				++nchanged;
 			}
 		#endif	// CONFIG_JACK_METADATA
+			foreach (qjackctlAliasList *port_aliases, item_aliases(*port))
+				port_title = port_aliases->portAlias(client_name, port_name);
 			if ((*port)->portTitle() != port_title) {
 				(*port)->setPortTitle(port_title);
 				++nchanged;


### PR DESCRIPTION
Followup to #198 which gives qjackctlJackClient::updateClientName() the same treatment as qjackctlJackPort::updatePortName(). The second commit deals with the graph window, making sure that edits take priority over metadata pretty-names, so that those edits aren't overwritten by the default metadata being set by Jack2.