### PR TITLE
- Manpage/qjackctl.1: Adjust D-BUS INTERFACE Section Format

### DIFF
--- a/src/man1/qjackctl.1
+++ b/src/man1/qjackctl.1
@@ -42,33 +42,81 @@ Show help about command line options
 \fB\-v\fR, \fB\-\-version\fR
 .IP
 Show version information.
-.SH D-Bus insterface
-Enable `Setup > Misc > Other > Enable D-Bus interface` to use the D-Bus interface commands as shown below.
+.SH D-BUS INTERFACE
+Enable 'Setup > Misc > Other > Enable D-Bus interface' to use the D-Bus interface commands as shown below.
 .PP
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.start\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.stop\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.reset\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.main\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.messages\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.status\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.session\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.connections\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.patchbay\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.graph\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.rewind\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.backward\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.play\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.pause\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.forward\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.setup\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.about\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.quit\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.preset string\fR:[\fIlabel\fR]
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.active-patchbay string\fR:[\fIpath\fR]
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.load\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.save\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.savequit\fR
-\fB\dbus\-send \-\-system / org.rncbc.qjackctl.savetemplate\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.start\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.stop\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.reset\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.main\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.messages\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.status\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.session\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.connections\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.patchbay\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.graph\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.rewind\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.backward\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.play\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.pause\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.forward\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.setup\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.about\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.quit\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.preset string\fR:[\fIlabel\fR]
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.active-patchbay string\fR:[\fIpath\fR]
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.load\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.save\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.savequit\fR
+.RE
+.RS
+\fBdbus\-send \-\-system / org.rncbc.qjackctl.savetemplate\fR
 .PP
 .SH SEE ALSO
 .BR jackd (1)


### PR DESCRIPTION
- Change the D-bus interface title to uppercase and Fix typos
- Adjust the body format of the D-BUS INTERFACE

# Before:
<img width="1353" height="658" alt="before_20250904-222453_screenshot" src="https://github.com/user-attachments/assets/50e06350-ee6b-4df6-bb68-c16e95d55138" />

# After:
<img width="1354" height="924" alt="after_20250904-222515_screenshot" src="https://github.com/user-attachments/assets/4d624365-31ed-422a-bb07-3324be789a9c" />
